### PR TITLE
Added configuration to send emails to only chairmen of groups

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1691,7 +1691,7 @@ return array(
                             'route' => '/senda[/:type]',
                             'constraints' => array(
                                 'id' => '[a-zA-Z][a-zA-Z0-9_-]*',
-                                'type' => 'allir|formenn'
+                                'type' => 'allir|formenn|stjornendur'
                             ),
                             'defaults' => array(
                                 'controller' => 'Stjornvisi\Controller\Email',

--- a/src/Stjornvisi/Controller/EmailController.php
+++ b/src/Stjornvisi/Controller/EmailController.php
@@ -101,7 +101,6 @@ class EmailController extends AbstractActionController
                         //SEND
                         //  send out full e-mail
                     } else {
-                        $param = $this->params()->fromRoute('type');
                         $this->getEventManager()->trigger('notify', $this, [
                             'action' => 'Stjornvisi\Notify\All',
                             'data' => (object)array(

--- a/src/Stjornvisi/Controller/EmailController.php
+++ b/src/Stjornvisi/Controller/EmailController.php
@@ -101,6 +101,7 @@ class EmailController extends AbstractActionController
                         //SEND
                         //  send out full e-mail
                     } else {
+                        $param = $this->params()->fromRoute('type');
                         $this->getEventManager()->trigger('notify', $this, [
                             'action' => 'Stjornvisi\Notify\All',
                             'data' => (object)array(

--- a/src/Stjornvisi/Notify/All.php
+++ b/src/Stjornvisi/Notify/All.php
@@ -116,7 +116,6 @@ class All implements NotifyInterface, QueueConnectionAwareInterface, DataStoreIn
     {
         $emailId = $this->getHash();
         $users = $this->getUsers($this->params->sender_id, $this->params->recipients, $this->params->test);
-
         $this->logger->info("Notify All ({$this->params->recipients})");
 
         //MAIL
@@ -267,11 +266,27 @@ class All implements NotifyInterface, QueueConnectionAwareInterface, DataStoreIn
         $user->setDataSource($this->getDataSourceDriver())
             ->setEventManager($this->getEventManager());
 
-        return ($test)
-            ? [$user->get($sender)]
-            :  (($recipients == 'allir')
-                ? $user->fetchAll(true)
-                :  $user->fetchAllLeaders(true)) ;
+        $recipientAddresses = [];
+
+        if($test) {
+            return [$user->get($sender)];
+        } else {
+           switch($recipients){
+
+               case "formenn" :
+                   $recipientAddresses = $user->fetchAllManagers(true);
+                   break;
+               case "stjornendur" :
+                   $recipientAddresses = $user->fetchAllLeaders(true);
+                   break;
+               case "allir" :
+                   $user->fetchAll(true);
+                   break;
+               default :
+                   $recipientAddresses = [];
+           }
+        }
+        return $recipientAddresses;
     }
 
     /**

--- a/src/Stjornvisi/Notify/All.php
+++ b/src/Stjornvisi/Notify/All.php
@@ -268,10 +268,10 @@ class All implements NotifyInterface, QueueConnectionAwareInterface, DataStoreIn
 
         $recipientAddresses = [];
 
-        if($test) {
+        if ($test) {
             return [$user->get($sender)];
         } else {
-           switch($recipients){
+           switch ($recipients){
 
                case "formenn" :
                    $recipientAddresses = $user->fetchAllManagers(true);

--- a/src/Stjornvisi/View/Helper/SubMenu.php
+++ b/src/Stjornvisi/View/Helper/SubMenu.php
@@ -207,9 +207,16 @@ class SubMenu extends AbstractHelper
                                     array(
                                         'label' => 'Stjórnendur',
                                         'id' => 'mail-all',
-                                        'uri' => $view->url('email/send', array('type'=>'formenn')),
+                                        'uri' => $view->url('email/send', array('type'=>'stjornendur')),
                                         'class' => 'icon-mail',
                                         'title' => 'Senda póst á stjórnendur faghópa'
+                                    ),
+                                    array(
+                                        'label' => 'Formenn',
+                                        'id' => 'mail-all',
+                                        'uri' => $view->url('email/send', array('type'=>'formenn')),
+                                        'class' => 'icon-mail',
+                                        'title' => 'Senda póst á formenn faghópa'
                                     ),
                                 )
                             ),


### PR DESCRIPTION
We got a request to add an action to the Emailer, so Gunnhildur could send emails only to the chairmen of the groups.  This PR handles that.

# What was done
* First I added the keyword formenn into the routing, so that could be picked up. 
* Nothing had to be done within the controllers, since we were just enhancing the actions.
* I refactored the Notify/All, so instead of ternary operators I put in a switch statement, to handle which of the three keywords (allir/stjornendur/formenn) was coming in, to determine the recipient list.
* Finally I added a new function in the User service to fetch all chairmen of all the groups.

After the coding was done, menu links were added and edited.

![screen shot 2015-08-23 at 17 44 40](https://cloud.githubusercontent.com/assets/7986212/9429422/efe7625e-49be-11e5-922c-d94fa1ddf05e.png)
